### PR TITLE
Add production Docker build and CI deploy pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+README.md
+src/node_modules
+src/**/node_modules
+src/.turbo
+src/coverage
+src/**/coverage
+src/jest-coverage
+src/**/jest-coverage
+src/.env
+src/.env.*
+src/**/.env
+src/**/.env.*
+src/**/certs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,11 @@ jobs:
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             echo "environment=prod" >> "$GITHUB_OUTPUT"
             echo "image_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "devtools=false" >> "$GITHUB_OUTPUT"
           else
             echo "environment=dev" >> "$GITHUB_OUTPUT"
             echo "image_tag=dev-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "devtools=true" >> "$GITHUB_OUTPUT"
           fi
           echo "image=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
 
@@ -114,6 +116,8 @@ jobs:
           push: false
           load: true
           tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.image_tag }}
+          build-args: |
+            VITE_ENABLE_DEVTOOLS=${{ steps.meta.outputs.devtools }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,149 @@
 name: CI
+
 on:
+  push:
+    branches: [main, develop]
+    tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+
 jobs:
   lint-and-test:
+    name: Lint + Typy + Testy + Build
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src
     steps:
       - uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: pnpm/action-setup@v5
         with:
           version: 10.33.0
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"
           cache-dependency-path: src/pnpm-lock.yaml
+
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+
       - run: pnpm lint
       - run: pnpm check-types
       - run: pnpm build
       - run: pnpm test:ci
+
+  docker-build-check:
+    name: Docker Build Test
+    needs: lint-and-test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kódu
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test build produkčního image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: consumption-web:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image na zranitelnosti (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: consumption-web:test
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true
+
+  build-and-push:
+    name: Build & Push Image
+    needs: lint-and-test
+    # jen push do develop (dev deploy) nebo vytvoreni verzoveho tagu (prod
+    # deploy) - obycejny push/merge do main bez tagu nema nic spoustet
+    if: |
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout kódu
+        uses: actions/checkout@v4
+
+      - name: Určení cílového prostředí a tagu image
+        id: meta
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "environment=prod" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=dev" >> "$GITHUB_OUTPUT"
+            echo "image_tag=dev-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "image=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (lokálně, pro scan před pushem)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image na zranitelnosti (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.image_tag }}
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true
+
+      - name: Push image do GHCR
+        run: docker push ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.image_tag }}
+
+      - name: Aktualizovat image tag v gitops repu (dev)
+        if: steps.meta.outputs.environment == 'dev'
+        run: |
+          git clone https://x-access-token:${{ secrets.GITOPS_REPO_TOKEN }}@github.com/jr-consumption-tracker/consumption-gitops.git gitops
+          cd gitops
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          sed -i "s|newTag: .*|newTag: ${{ steps.meta.outputs.image_tag }}|" apps/web/overlays/dev/kustomization.yaml
+          if git diff --quiet; then
+            echo "Tag se nezmenil, nic k commitnuti."
+            exit 0
+          fi
+          git add apps/web/overlays/dev/kustomization.yaml
+          git commit -m "Deploy web ${{ steps.meta.outputs.image_tag }} to dev"
+          git push
+
+      # Az bude existovat apps/web/overlays/prod, pridame stejny krok
+      # podmineny na steps.meta.outputs.environment == 'prod'.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,10 @@ RUN corepack enable && pnpm install --frozen-lockfile
 # za spolecnou domenou s API) - proto se pec do image pri buildu, misto
 # aby se cetly za behu jako u backendu. Vite je stejne peče do JS pri
 # 'vite build', za behu uz je nejde zmenit.
+#
+# JEDEN Dockerfile pro dev i prod - CI pro kazde prostredi jen preda jine
+# --build-arg (viz .github/workflows/ci.yml, VITE_ENABLE_DEVTOOLS=true pro
+# dev, false pro prod). Zadny duvod mit druhy Dockerfile jen kvuli tomuhle.
 ARG VITE_PUBLIC_URL=/
 ARG VITE_API_BASE_URL=/api
 ARG VITE_ENABLE_DEVTOOLS=false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-alpine AS build
+WORKDIR /app
+COPY src/ .
+RUN corepack enable && pnpm install --frozen-lockfile
+
+# Hodnoty nejsou tajne (relativni cesty, fungujici pro kterekoliv prostredi
+# za spolecnou domenou s API) - proto se pec do image pri buildu, misto
+# aby se cetly za behu jako u backendu. Vite je stejne peče do JS pri
+# 'vite build', za behu uz je nejde zmenit.
+ARG VITE_PUBLIC_URL=/
+ARG VITE_API_BASE_URL=/api
+ARG VITE_ENABLE_DEVTOOLS=false
+RUN { \
+      echo "VITE_PUBLIC_URL=\"${VITE_PUBLIC_URL}\""; \
+      echo "VITE_API_BASE_URL=\"${VITE_API_BASE_URL}\""; \
+      echo "VITE_ENABLE_DEVTOOLS=\"${VITE_ENABLE_DEVTOOLS}\""; \
+    } > apps/web/.env.production
+
+RUN pnpm --filter web build:production
+
+FROM nginx:1.27-alpine AS runtime
+COPY --from=build /app/apps/web/dist /usr/share/nginx/html
+COPY docker/prod/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,12 @@ RUN { \
 RUN pnpm --filter web build:production
 
 FROM nginx:1.27-alpine AS runtime
+
+# Alpine balicky v samotnem base image casem zastaravaji (i kdyz je tag
+# "1.27-alpine" fixni) - apk upgrade stahne aktualni bezpecnostni zalatky
+# bez ohledu na to, jak stary je konkretni base image tag.
+RUN apk update && apk upgrade --no-cache
+
 COPY --from=build /app/apps/web/dist /usr/share/nginx/html
 COPY docker/prod/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/docker/prod/nginx.conf
+++ b/docker/prod/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /healthz {
+        access_log off;
+        return 200 "ok";
+        add_header Content-Type text/plain;
+    }
+
+    # SPA - klientsky routing (TanStack Router), fallback na index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- `docker/Dockerfile` - multi-stage, pnpm/turbo build -> nginx statický serving
- `docker/prod/nginx.conf` - SPA fallback + `/healthz`
- CI rozšířeno o `develop`/tag triggery, Trivy scan, build-and-push do GHCR, automatický zápis tagu do `consumption-gitops`

## Test plan
- [ ] `docker-build-check` na tomhle PR proběhne bez chyby