### PR TITLE
Switch to a single main branch, drop develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   lint-and-test:
@@ -71,11 +71,11 @@ jobs:
   build-and-push:
     name: Build & Push Image
     needs: lint-and-test
-    # jen push do develop (dev deploy) nebo vytvoreni verzoveho tagu (prod
-    # deploy) - obycejny push/merge do main bez tagu nema nic spoustet
+    # kazdy push/merge do main (bez tagu) = dev deploy, vytvoreni
+    # verzoveho tagu = prod deploy - zadna zvlastni develop vetev
     if: |
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- CI `build-and-push` trigger changed from push-to-`develop` to push-to-`main` (tag trigger for prod unchanged)
- Feature branches now PR directly into `main` instead of `develop`
- `develop` is no longer used - having both `develop` and `main` protected meant every change needed two PRs (into develop, then develop into main for a release) for no real benefit, since main was already effectively the only branch anyone worked off day to day

## Test plan
- [ ] Verify `lint-and-test`/`docker-build-check` pass on this PR
- [ ] After merge, confirm a normal push to `main` triggers `build-and-push` and deploys to dev as expected