### PR TITLE
Fix TypeError crash on Pricing/Home when translations haven't loaded yet

### DIFF
--- a/src/apps/web/src/shared/ui/PricingCard/PricingCard.tsx
+++ b/src/apps/web/src/shared/ui/PricingCard/PricingCard.tsx
@@ -92,7 +92,7 @@ export const PricingCard = ({ plan }: PricingCardProps) => {
             highlighted ? "text-dark-block-text" : "text-text-muted",
           )}
         >
-          {features?.map((feature, idx) => (
+          {Array.isArray(features) && features.map((feature, idx) => (
             <li
               key={idx}
               className={cn(

--- a/src/apps/web/src/widgets/home/HomePricing/ui/HomePricing.tsx
+++ b/src/apps/web/src/widgets/home/HomePricing/ui/HomePricing.tsx
@@ -8,11 +8,16 @@ import { Section } from "@web/shared/ui/Section";
 import type { TFunction } from "i18next";
 import type { PricingPlan } from "@web/shared/model/types";
 
+const asFeatureArray = (value: unknown): string[] =>
+  Array.isArray(value) ? value : [];
+
 const getPricingPlans = (t: TFunction<"home">): PricingPlan[] => [
   {
     name: t("pricing.plans.free.name"),
     price: 0,
-    features: t("pricing.plans.free.features", { returnObjects: true }),
+    features: asFeatureArray(
+      t("pricing.plans.free.features", { returnObjects: true }),
+    ),
     cta: t("pricing.plans.free.cta"),
     ctaLink: "/auth/register",
   },
@@ -20,7 +25,9 @@ const getPricingPlans = (t: TFunction<"home">): PricingPlan[] => [
     name: t("pricing.plans.premium.name"),
     price: 49,
     interval: t("pricing.plans.premium.interval"),
-    features: t("pricing.plans.premium.features", { returnObjects: true }),
+    features: asFeatureArray(
+      t("pricing.plans.premium.features", { returnObjects: true }),
+    ),
     cta: t("pricing.plans.premium.cta"),
     ctaLink: "/auth/register",
     badge: t("pricing.plans.premium.badge"),

--- a/src/apps/web/src/widgets/pricing/PricingFaq/PricingFaq.tsx
+++ b/src/apps/web/src/widgets/pricing/PricingFaq/PricingFaq.tsx
@@ -7,10 +7,11 @@ import type { AccordionItem } from "@web/shared/ui/Accordion";
 import type { TFunction } from "i18next";
 
 const getFaqItems = (t: TFunction<"pricing">): AccordionItem[] => {
-  const items = t("faq.items", { returnObjects: true }) as {
-    question: string;
-    answer: string;
-  }[];
+  const items = t("faq.items", { returnObjects: true });
+
+  if (!Array.isArray(items)) {
+    return [];
+  }
 
   return items.map((item) => ({
     title: item.question,


### PR DESCRIPTION
## Summary
- Fixes a production-only crash (`TypeError: ...map is not a function`) on hard refresh of `/` (home pricing section) and `/cenik` (pricing FAQ)
- Root cause: `useSuspense: false` in i18next config means components render immediately, before the async-loaded translation namespace JSON has necessarily arrived. Until it does, `t(key, { returnObjects: true })` returns the missing-key string instead of an array - there was a type assertion (`as {...}[]`) but no runtime guard
- Reliably reproduces on hard refresh (not in-app SPA navigation, where namespaces are already cached from the initial load) - confirmed on the deployed dev environment

## Changes
- `HomePricing.tsx`: `features` built from `returnObjects` now goes through `Array.isArray` before use
- `PricingCard.tsx`: defense in depth at the consuming side (`features?.map` → `Array.isArray(features) && features.map`)
- `PricingFaq.tsx`: same guard for `faq.items`

## Test plan
- [x] `tsc -b` and `build:production` pass locally
- [ ] After merge/deploy, hard-refresh `/` and `/cenik` a few times on the dev environment to confirm no more console errors