### PR TITLE
Fix duplicate /api/api prefix on production API calls

### DIFF
--- a/src/apps/web/src/shared/api/axiosMainApi.ts
+++ b/src/apps/web/src/shared/api/axiosMainApi.ts
@@ -8,7 +8,7 @@ import type { AuthSession } from "@web/features/auth/model/types/credentials";
 const MAIN_API_BASE_URL =
   import.meta.env.MODE !== "production" && import.meta.env.MODE !== "test"
     ? "/api"
-    : `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "")}/api`;
+    : import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "");
 
 export const axiosMainApi = axios.create({
   baseURL: MAIN_API_BASE_URL,


### PR DESCRIPTION
## Summary
- Production/test builds requested `/api/api/...` instead of `/api/...` - confirmed on the deployed dev environment (`https://spotreba-energie.local/api/api/web/auth/login`)
- Cause: `MAIN_API_BASE_URL` appended a literal `"/api"` onto `VITE_API_BASE_URL`, but that env var is already the full base path (defaults to `/api` in `docker/Dockerfile`)
- Dev mode never hit this since it uses a hardcoded `"/api"` with no concatenation, which is why it wasn't caught locally

## Test plan
- [x] `build:production` passes locally
- [ ] After merge/deploy, confirm login and other API calls hit `/api/...` (not `/api/api/...`) on the dev environment